### PR TITLE
feat(helm): fix quickwit deployment

### DIFF
--- a/scripts/helmcharts/openreplay/charts/quickwit/templates/deployment.yaml
+++ b/scripts/helmcharts/openreplay/charts/quickwit/templates/deployment.yaml
@@ -50,7 +50,6 @@ spec:
               value: "{{ .Values.global.s3.region }}"
             - name: QW_S3_ENDPOINT
               value: '{{ .Values.global.s3.endpoint }}'
-              {{- end}}
             - name: AWS_ACCESS_KEY_ID
               value: {{ .Values.global.s3.accessKey }}
             - name: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Helm templating currently fails due to a stray `{{- end}}` tag. The issue was introduced here: scripts/helmcharts/openreplay/charts/quickwit/templates/deployment.yaml